### PR TITLE
Outlink to solar flare data opens in new tab

### DIFF
--- a/All_Project_code_and_components/src/views/pages/dashboard.ejs
+++ b/All_Project_code_and_components/src/views/pages/dashboard.ejs
@@ -54,7 +54,7 @@
                                 <td><%= solarFlares.data[0].sourceLocation %></td>
                             </tr>
                             <tr>
-                                <td><a style="font-family: Verdana, Geneva, Tahoma, sans-serif;color: aqua;"href="<%= solarFlares.data[0].link %>"> Recent solar flare full data - NASA Website</a></td>
+                                <td><a target="_blank" style="font-family: Verdana, Geneva, Tahoma, sans-serif;color: aqua;"href="<%= solarFlares.data[0].link %>"> Recent solar flare full data - NASA Website</a></td>
                             </tr>
                         </table>
                         


### PR DESCRIPTION
When user clicks on the link on the solar flare table, the full entry by NASA will now open in a new tab